### PR TITLE
RU: fix hull meter and reactor upgrade strings

### DIFF
--- a/auxfiles-ru/data/text-ru.xml.append
+++ b/auxfiles-ru/data/text-ru.xml.append
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FTL>
+  <text name="status_hull" language="ru">КОР.</text>
+  <text name="upgrade_reactor_power" language="ru"> ЕД. ЭНЕРГИИ</text>
+</FTL>


### PR DESCRIPTION
Hull meter text was too long and obstructed the actual amount of HP left, and the reactor button at system upgrade screen still had vanilla text despite the energy amount having been moved.
![image](https://user-images.githubusercontent.com/63517545/189177533-59b5bb59-058e-4b3e-9c1a-b8657d99f7ce.png)
